### PR TITLE
Fix the bug in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         "click",
         "jinja2",
-        "pefile>=2019.4.18, <2019.5.0"
+        "pefile>=2019.4.18, <2019.5.0",
         "pyyaml>=5.1",
         "sqlalchemy>=1.4, <1.5",
         "alembic>=1.7.4, <1.8",


### PR DESCRIPTION
Hello, when I cloned this code repository and installed it using `pip install .`, I encountered an error in `setup.py` regarding `install_requires(dependencies)`. I hope to fix this bug through this pull request. 

Thank you.

Fixing the bug for cloning the code repository and installing with the `pip install .` command.